### PR TITLE
Add option for custom fail colour

### DIFF
--- a/LockGlyphX.xm
+++ b/LockGlyphX.xm
@@ -720,13 +720,13 @@ static void performShakeFingerFailAnimation(void) {
                 DebugLog(@"TouchID: match failed");
                 if (customFailColorEnabled) {
                 	fingerglyph.secondaryColor = failColor;
+                	dispatch_after(dispatch_time( DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC ), dispatch_get_main_queue(), ^{
+   						fingerglyph.secondaryColor = activeSecondaryColor();
+					});
                 }
                	if (shakeOnIncorrectFinger) {
                     performShakeFingerFailAnimation();
                 }
-				dispatch_after(dispatch_time( DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC ), dispatch_get_main_queue(), ^{
-   					fingerglyph.secondaryColor = activeSecondaryColor();
-				});
                 if (vibrateOnIncorrectFinger && ![manager.lockScreenViewController isPasscodeLockVisible]) {
                     AudioServicesPlaySystemSound(kSystemSoundID_Vibrate);
                 }
@@ -820,13 +820,13 @@ static void performShakeFingerFailAnimation(void) {
                 DebugLog(@"TouchID: match failed");
                 if (customFailColorEnabled) {
                 	fingerglyph.secondaryColor = failColor;
+                	dispatch_after(dispatch_time( DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC ), dispatch_get_main_queue(), ^{
+   						fingerglyph.secondaryColor = activeSecondaryColor();
+					});
                 }
                	if (shakeOnIncorrectFinger) {
                     performShakeFingerFailAnimation();
                 }
-				dispatch_after(dispatch_time( DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC ), dispatch_get_main_queue(), ^{
-   					fingerglyph.secondaryColor = activeSecondaryColor();
-				});
                 if (vibrateOnIncorrectFinger && ![manager.lockScreenViewController isPasscodeLockVisible]) {
                     AudioServicesPlaySystemSound(kSystemSoundID_Vibrate);
                 }

--- a/LockGlyphX.xm
+++ b/LockGlyphX.xm
@@ -41,6 +41,7 @@
 
 #define kDefaultPrimaryColor 	[UIColor colorWithWhite:1 alpha:1]
 #define kDefaultSecondaryColor 	[UIColor colorWithWhite:0.8 alpha:1] //#cccccc
+#define kDefaultFailColor		[UIColor colorWithRed: 255.0/255.0 green: 0.0/255.0 blue: 0.0/255.0 alpha: 1.0]
 
 #define kDefaultYOffset 					90.0f
 #define kDefaultYOffsetWithLockLabelHidden 	64.0f
@@ -85,6 +86,8 @@ static BOOL useShine;
 static BOOL shouldNotDelay;
 static UIColor *primaryColor;
 static UIColor *secondaryColor;
+static BOOL customFailColorEnabled;
+static UIColor *failColor; 
 static BOOL enablePortraitY;
 static CGFloat portraitY;
 static BOOL enableLandscapeY;
@@ -169,6 +172,8 @@ static void loadPreferences() {
 	shouldNotDelay = !CFPreferencesCopyAppValue(CFSTR("shouldNotDelay"), kPrefsAppID) ? NO : [CFBridgingRelease(CFPreferencesCopyAppValue(CFSTR("shouldNotDelay"), kPrefsAppID)) boolValue];
 	primaryColor = !CFPreferencesCopyAppValue(CFSTR("primaryColor"), kPrefsAppID) ? kDefaultPrimaryColor : parseColorFromPreferences(CFBridgingRelease(CFPreferencesCopyAppValue(CFSTR("primaryColor"), kPrefsAppID)));
 	secondaryColor = !CFPreferencesCopyAppValue(CFSTR("secondaryColor"), kPrefsAppID) ? kDefaultSecondaryColor : parseColorFromPreferences(CFBridgingRelease(CFPreferencesCopyAppValue(CFSTR("secondaryColor"), kPrefsAppID)));
+	customFailColorEnabled = !CFPreferencesCopyAppValue(CFSTR("customFailColorEnabled"), kPrefsAppID) ? NO : [CFBridgingRelease(CFPreferencesCopyAppValue(CFSTR("customFailColorEnabled"), kPrefsAppID)) boolValue];
+	failColor = !CFPreferencesCopyAppValue(CFSTR("failColor"), kPrefsAppID) ? kDefaultFailColor : parseColorFromPreferences(CFBridgingRelease(CFPreferencesCopyAppValue(CFSTR("failColor"), kPrefsAppID)));
 	enablePortraitY = !CFPreferencesCopyAppValue(CFSTR("enablePortraitY"), kPrefsAppID) ? NO : [CFBridgingRelease(CFPreferencesCopyAppValue(CFSTR("enablePortraitY"), kPrefsAppID)) boolValue];
 	portraitY = !CFPreferencesCopyAppValue(CFSTR("portraitY"), kPrefsAppID) ? 0 : [CFBridgingRelease(CFPreferencesCopyAppValue(CFSTR("portraitY"), kPrefsAppID)) floatValue];
 	enableLandscapeY = !CFPreferencesCopyAppValue(CFSTR("enableLandscapeY"), kPrefsAppID) ? NO : [CFBridgingRelease(CFPreferencesCopyAppValue(CFSTR("enableLandscapeY"), kPrefsAppID)) boolValue];
@@ -713,9 +718,15 @@ static void performShakeFingerFailAnimation(void) {
             case kTouchIDDisabled:
                 canStartFingerDownAnimation = NO;
                 DebugLog(@"TouchID: match failed");
-                if (shakeOnIncorrectFinger) {
+                if (customFailColorEnabled) {
+                	fingerglyph.secondaryColor = failColor;
+                }
+               	if (shakeOnIncorrectFinger) {
                     performShakeFingerFailAnimation();
                 }
+				dispatch_after(dispatch_time( DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC ), dispatch_get_main_queue(), ^{
+   					fingerglyph.secondaryColor = activeSecondaryColor();
+				});
                 if (vibrateOnIncorrectFinger && ![manager.lockScreenViewController isPasscodeLockVisible]) {
                     AudioServicesPlaySystemSound(kSystemSoundID_Vibrate);
                 }
@@ -807,9 +818,15 @@ static void performShakeFingerFailAnimation(void) {
             case kTouchIDDisabled:
                 canStartFingerDownAnimation = NO;
                 DebugLog(@"TouchID: match failed");
-                if (shakeOnIncorrectFinger) {
+                if (customFailColorEnabled) {
+                	fingerglyph.secondaryColor = failColor;
+                }
+               	if (shakeOnIncorrectFinger) {
                     performShakeFingerFailAnimation();
                 }
+				dispatch_after(dispatch_time( DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC ), dispatch_get_main_queue(), ^{
+   					fingerglyph.secondaryColor = activeSecondaryColor();
+				});
                 if (vibrateOnIncorrectFinger && ![manager.lockScreenViewController isPasscodeLockVisible]) {
                     AudioServicesPlaySystemSound(kSystemSoundID_Vibrate);
                 }

--- a/Prefs/Resources/LockGlyphXPrefs-Appearance.plist
+++ b/Prefs/Resources/LockGlyphXPrefs-Appearance.plist
@@ -157,7 +157,7 @@
 			<key>key</key>
 			<string>customFailColorEnabled</string>
 			<key>label</key>
-			<string>COLORS_USE_CUSTOM_FAILCOLOR</string>
+			<string>COLOURS_USE_CUSTOM_FAILCOLOR</string>
 			<key>PostNotification</key>
 			<string>com.evilgoldfish.lockglyphx.settingschanged</string>
 		</dict>

--- a/Prefs/Resources/LockGlyphXPrefs-Appearance.plist
+++ b/Prefs/Resources/LockGlyphXPrefs-Appearance.plist
@@ -144,6 +144,46 @@
 			<key>color_postNotification</key>
 			<string>com.evilgoldfish.lockglyphx.settingschanged</string>
 		</dict>
+		<!-- Use custom Fail Color -->
+		<dict>
+			<key>cell</key>
+			<string>PSSwitchCell</string>
+			<key>cellClass</key>
+			<string>LGXSwitchCell</string>
+			<key>default</key>
+			<false/>
+			<key>defaults</key>
+			<string>com.evilgoldfish.lockglyphx</string>
+			<key>key</key>
+			<string>customFailColorEnabled</string>
+			<key>label</key>
+			<string>COLORS_USE_CUSTOM_FAILCOLOR</string>
+			<key>PostNotification</key>
+			<string>com.evilgoldfish.lockglyphx.settingschanged</string>
+		</dict>
+		<!-- Custom fail colour -->
+		<dict>
+			<key>cell</key>
+			<string>PSLinkCell</string>
+			<key>cellClass</key>
+			<string>PFColorCell</string>
+			<key>label</key>
+			<string>COLOURS_FAILCOLOR_LABEL</string>
+			<key>color_defaults</key>
+			<string>com.evilgoldfish.lockglyphx</string>
+			<key>color_key</key>
+			<string>failColor</string>
+			<key>title</key>
+			<string>COLOURS_FAILCOLOR_LABEL</string>
+			<key>color_fallback</key>
+			<string>#FF0000</string>
+			<key>usesRGB</key>
+			<true/>
+			<key>usesAlpha</key>
+			<true/>
+			<key>color_postNotification</key>
+			<string>com.evilgoldfish.lockglyphx.settingschanged</string>
+		</dict>
 		<!-- Apply To Custom Glyphs -->
 		<dict>
 			<key>cell</key>

--- a/Prefs/Resources/en.lproj/Localizable.strings
+++ b/Prefs/Resources/en.lproj/Localizable.strings
@@ -37,6 +37,8 @@
 "COLOURS_IDLECOLOUR_LABEL" = "Glyph colour";
 "COLOURS_IDLECOLOUR_OVERRIDE_LABEL" = "Apply to custom glyphs";
 "COLOURS_SCANCOLOUR_LABEL" = "Scanning colour";
+"COLORS_USE_CUSTOM_FAILCOLOR" = "Use custom fail color";
+"COLOURS_FAILCOLOR_LABEL" = "Scan fail colour";
 
 "COLOURS_RESET_LABEL" = "Reset colours to default";
 "LOCKLABEL_HEADER_TEXT" = "Press Home To Unlock";

--- a/Prefs/Resources/en.lproj/Localizable.strings
+++ b/Prefs/Resources/en.lproj/Localizable.strings
@@ -37,7 +37,7 @@
 "COLOURS_IDLECOLOUR_LABEL" = "Glyph colour";
 "COLOURS_IDLECOLOUR_OVERRIDE_LABEL" = "Apply to custom glyphs";
 "COLOURS_SCANCOLOUR_LABEL" = "Scanning colour";
-"COLORS_USE_CUSTOM_FAILCOLOR" = "Use custom fail color";
+"COLOURS_USE_CUSTOM_FAILCOLOR" = "Use custom fail color";
 "COLOURS_FAILCOLOR_LABEL" = "Scan fail colour";
 
 "COLOURS_RESET_LABEL" = "Reset colours to default";


### PR DESCRIPTION
As with any settings update, this will require two additional localisations:

`COLORS_USE_CUSTOM_FAILCOLOR`, which is shown on the switch to enable a custom failcolour
`COLOURS_SCANCOLOUR_LABEL`, which is shown on the cell to pick a custom colour.

This setting will not change anything if the custom failcolor is not enabled. If it is, it will introduce the following behaviours:

- The glyph will delay for two seconds before changing back to it's default state
- The secondary colour will change to the user specified color for the duration of the fail.

I'm not too tired, so there shouldn't be too many mistakes, but feel free to point out things I can do better. 

I think this should be held off release (hence the branch) until someone can get around to either refactoring settings, or completing this todo.

# Todo

- [ ] Hide the custom color cell if the custom fail color is not enabled
